### PR TITLE
Enhancement/kpref single recycler

### DIFF
--- a/adapter/src/main/kotlin/ca/allanwang/kau/adapters/ChainedAdapters.kt
+++ b/adapter/src/main/kotlin/ca/allanwang/kau/adapters/ChainedAdapters.kt
@@ -2,6 +2,7 @@ package ca.allanwang.kau.adapters
 
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
+import ca.allanwang.kau.utils.withLinearAdapter
 import com.mikepenz.fastadapter.IItem
 import com.mikepenz.fastadapter.adapters.HeaderAdapter
 import com.mikepenz.fastadapter.commons.adapters.FastItemAdapter
@@ -55,8 +56,7 @@ class ChainedAdapters<T>(vararg items: Pair<T, SectionAdapter<*>>) {
         recycler = recyclerView
         indexStack.push(0)
         with(recyclerView) {
-            layoutManager = LinearLayoutManager(context)
-            adapter = chain.first().second
+            withLinearAdapter(chain.first().second)
             addOnScrollListener(object : RecyclerView.OnScrollListener() {
                 override fun onScrolled(rv: RecyclerView, dx: Int, dy: Int) {
                     super.onScrolled(rv, dx, dy)

--- a/adapter/src/main/kotlin/ca/allanwang/kau/animators/BaseItemAnimator.java
+++ b/adapter/src/main/kotlin/ca/allanwang/kau/animators/BaseItemAnimator.java
@@ -485,7 +485,7 @@ public abstract class BaseItemAnimator extends SimpleItemAnimator {
     public abstract ViewPropertyAnimator changeNewAnimation(ViewHolder holder);
 
     /**
-     * the cleanup method if the animation needs to be stopped. and tro prepare for the next view
+     * the cleanup method if the animation needs to be stopped. and to prepare for the next view
      *
      * @param holder
      */

--- a/core/src/main/kotlin/ca/allanwang/kau/utils/ViewUtils.kt
+++ b/core/src/main/kotlin/ca/allanwang/kau/utils/ViewUtils.kt
@@ -211,13 +211,19 @@ inline val TextInputEditText.value: String get() = text.toString().trim()
 /**
  * Generates a recycler view with match parent and a linearlayoutmanager, since it's so commonly used
  */
-fun Context.fullLinearRecycler(rvAdapter: RecyclerView.Adapter<*>? = null, configs: RecyclerView.() -> Unit = {}): RecyclerView {
-    return RecyclerView(this).apply {
-        layoutManager = LinearLayoutManager(this@fullLinearRecycler)
-        layoutParams = RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT, RecyclerView.LayoutParams.MATCH_PARENT)
-        if (rvAdapter != null) adapter = rvAdapter
-        configs()
-    }
+fun Context.fullLinearRecycler(rvAdapter: RecyclerView.Adapter<*>? = null, configs: RecyclerView.() -> Unit = {}) = RecyclerView(this).apply {
+    layoutManager = LinearLayoutManager(this@fullLinearRecycler)
+    layoutParams = RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT, RecyclerView.LayoutParams.MATCH_PARENT)
+    if (rvAdapter != null) adapter = rvAdapter
+    configs()
+}
+
+/**
+ * Sets a linear layout manager along with an adapter
+ */
+fun RecyclerView.withLinearAdapter(rvAdapter: RecyclerView.Adapter<*>) = apply {
+    layoutManager = LinearLayoutManager(context)
+    adapter = rvAdapter
 }
 
 /**

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,9 @@
 * :core: Create debounce methods
 * :core: Create zip methods
 * :core: [Breaking] Logging base has been renamed to KauLogger and no longer depends on timber
+* :kpref-activity: Rewrote binding logic to use only one recyclerview
+* :kpref-activity: Removed sliding toolbar and use normal toolbar title
+* :kpref-activity: Remove :core-ui: dependency
 * :searchview: [Breaking] remove reactive dependencies and stick with basic callbacks
 
 ## v3.2.5

--- a/kpref-activity/build.gradle
+++ b/kpref-activity/build.gradle
@@ -5,7 +5,6 @@ ext.kauSubModuleResourcePrefix = "kau_pref_"
 apply from: '../android-lib.gradle'
 
 dependencies {
-    compile project(':core-ui')
     compile project(':adapter')
     compile project(':colorpicker')
 }

--- a/kpref-activity/src/main/kotlin/ca/allanwang/kau/kpref/activity/KPrefBinder.kt
+++ b/kpref-activity/src/main/kotlin/ca/allanwang/kau/kpref/activity/KPrefBinder.kt
@@ -1,39 +1,13 @@
 package ca.allanwang.kau.kpref.activity
 
 import android.support.annotation.StringRes
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
-import ca.allanwang.kau.R
 import ca.allanwang.kau.kpref.activity.items.*
-import com.mikepenz.fastadapter.commons.adapters.FastItemAdapter
-import org.jetbrains.anko.doAsync
-import org.jetbrains.anko.uiThread
 
 /**
  * Created by Allan Wang on 2017-06-08.
  *
  * Houses all the components that can be called externally to setup the kpref mainAdapter
  */
-
-/**
- * Base extension that will register the layout manager and mainAdapter with the given items
- * Returns FastAdapter
- */
-fun RecyclerView.setKPrefAdapter(globalOptions: GlobalOptions, builder: KPrefAdapterBuilder.() -> Unit): FastItemAdapter<KPrefItemCore> {
-    layoutManager = LinearLayoutManager(context)
-    val adapter = FastItemAdapter<KPrefItemCore>()
-    adapter.withOnClickListener { v, _, item, _ -> item.onClick(v, v.findViewById(R.id.kau_pref_inner_content)) }
-    this.adapter = adapter
-    doAsync {
-        val items = KPrefAdapterBuilder(globalOptions)
-        builder.invoke(items)
-        uiThread {
-            adapter.add(items.list)
-        }
-    }
-    return adapter
-}
-
 @DslMarker
 annotation class KPrefMarker
 
@@ -70,6 +44,9 @@ class GlobalOptions(core: CoreAttributeContract, activity: KPrefActivityContract
  * Contains DSLs for every possible item
  * The arguments are all the mandatory values plus an optional builder housing all the possible configurations
  * The mandatory values are final so they cannot be edited in the builder
+ *
+ * This function will be called asynchronously, so don't worry about blocking the thread
+ * The recycler will only animate once this is completed though
  */
 @KPrefMarker
 class KPrefAdapterBuilder(val globalOptions: GlobalOptions) {

--- a/kpref-activity/src/main/res/layout/kau_pref_activity.xml
+++ b/kpref-activity/src/main/res/layout/kau_pref_activity.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/kau_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -22,16 +21,7 @@
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <ca.allanwang.kau.ui.widgets.TextSlider
-            android:id="@+id/kau_toolbar_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            app:animation_type="slide_horizontal" />
-
-    </android.support.v7.widget.Toolbar>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ca.allanwang.kau.ui.views.RippleCanvas
         android:id="@+id/kau_ripple"
@@ -42,8 +32,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/kau_toolbar" />
 
-    <ViewAnimator
-        android:id="@+id/kau_holder"
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/kau_recycler"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/sample/src/main/res/xml/kau_changelog.xml
+++ b/sample/src/main/res/xml/kau_changelog.xml
@@ -10,8 +10,10 @@
     <item text=":core: Create debounce methods" />
     <item text=":core: Create zip methods" />
     <item text=":core: [Breaking] Logging base has been renamed to KauLogger and no longer depends on timber" />
+    <item text=":kpref-activity: Rewrote binding logic to use only one recyclerview" />
+    <item text=":kpref-activity: Removed sliding toolbar and use normal toolbar title" />
+    <item text=":kpref-activity: Remove :core-ui: dependency" />
     <item text=":searchview: [Breaking] remove reactive dependencies and stick with basic callbacks" />
-    <item text="" />
     <item text="" />
     <item text="" />
     <item text="" />

--- a/searchview/src/main/kotlin/ca/allanwang/kau/searchview/SearchView.kt
+++ b/searchview/src/main/kotlin/ca/allanwang/kau/searchview/SearchView.kt
@@ -229,14 +229,13 @@ class SearchView @JvmOverloads constructor(
         tintBackground(configs.backgroundColor)
         with(recycler) {
             isNestedScrollingEnabled = false
-            layoutManager = LinearLayoutManager(context)
+            withLinearAdapter(this@SearchView.adapter)
             addOnScrollListener(object : RecyclerView.OnScrollListener() {
                 override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                     super.onScrollStateChanged(recyclerView, newState)
                     if (newState == RecyclerView.SCROLL_STATE_DRAGGING) hideKeyboard()
                 }
             })
-            adapter = this@SearchView.adapter
             itemAnimator = null
         }
         with(adapter) {


### PR DESCRIPTION
The KPref activity is rewritten with the following notable changes:

* No view switcher; we will instead use one recyclerview along with item animators
* No title switcher; we will deal with the basic toolbar title

As a result, we also no longer depend on :core-ui: