### PR TITLE
Add callback

### DIFF
--- a/sample/src/main/kotlin/ca/allanwang/kau/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/ca/allanwang/kau/sample/MainActivity.kt
@@ -230,6 +230,11 @@ class MainActivity : KPrefActivity() {
                 val items = wordBank.filter { it.contains(query) }.sorted().map { SearchItem(it) }
                 searchView.results = items
             }
+            searchCallback = {
+                query, _ ->
+                toast("Enter pressed for $query")
+                true
+            }
             textDebounceInterval = 0
             noResultsFound = R.string.kau_no_results_found
             shouldClearOnClose = false


### PR DESCRIPTION
Users can now subscribe to the keyboard action event.

If the search key is pressed, the keyboard will automatically hide. Users can handle the request and decide if they wish to close the search view