### PR TITLE
Fix/kpref-inner-frame-size

### DIFF
--- a/core/src/main/kotlin/ca/allanwang/kau/utils/Const.kt
+++ b/core/src/main/kotlin/ca/allanwang/kau/utils/Const.kt
@@ -19,3 +19,5 @@ const val KAU_COLLAPSED = 0
 const val KAU_COLLAPSING = 1
 const val KAU_EXPANDING = 2
 const val KAU_EXPANDED = 3
+
+const val KAU_ELLIPSIS = '\u2026'

--- a/core/src/main/kotlin/ca/allanwang/kau/utils/Utils.kt
+++ b/core/src/main/kotlin/ca/allanwang/kau/utils/Utils.kt
@@ -119,3 +119,7 @@ inline val kauIsMainThread: Boolean
     get() = Looper.myLooper() == Looper.getMainLooper()
 
 class KauException(message: String) : RuntimeException(message)
+
+fun String.withMaxLength(n: Int): String =
+        if (length <= n) this
+        else substring(0, n-1) + KAU_ELLIPSIS

--- a/kpref-activity/src/main/kotlin/ca/allanwang/kau/kpref/activity/items/KPrefSeekbar.kt
+++ b/kpref-activity/src/main/kotlin/ca/allanwang/kau/kpref/activity/items/KPrefSeekbar.kt
@@ -3,7 +3,6 @@ package ca.allanwang.kau.kpref.activity.items
 import android.view.View
 import android.widget.SeekBar
 import android.widget.TextView
-import ca.allanwang.kau.kpref.KPrefException
 import ca.allanwang.kau.kpref.activity.GlobalOptions
 import ca.allanwang.kau.kpref.activity.R
 import ca.allanwang.kau.utils.tint

--- a/kpref-activity/src/main/res/layout/kau_pref_core.xml
+++ b/kpref-activity/src/main/res/layout/kau_pref_core.xml
@@ -38,7 +38,7 @@
 
         <android.support.v7.widget.AppCompatTextView
             android:id="@id/kau_pref_title"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/kau_padding_normal"
             android:ellipsize="marquee"
@@ -53,7 +53,7 @@
 
         <android.support.v7.widget.AppCompatTextView
             android:id="@id/kau_pref_desc"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:maxLines="10"
@@ -81,16 +81,16 @@
 
         <android.support.constraint.Barrier
             android:id="@id/kau_pref_barrier"
-            android:layout_width="1dp"
-            android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:barrierDirection="end"
-            app:constraint_referenced_ids="kau_pref_title,kau_pref_desc,kau_pref_lower_frame"
+            app:constraint_referenced_ids="kau_pref_title,kau_pref_desc"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <LinearLayout
             android:id="@id/kau_pref_inner_frame"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="0dp"
             android:gravity="center_vertical|end"
             android:orientation="horizontal"

--- a/kpref-activity/src/main/res/layout/kau_pref_core.xml
+++ b/kpref-activity/src/main/res/layout/kau_pref_core.xml
@@ -38,7 +38,7 @@
 
         <android.support.v7.widget.AppCompatTextView
             android:id="@id/kau_pref_title"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/kau_padding_normal"
             android:ellipsize="marquee"
@@ -53,7 +53,7 @@
 
         <android.support.v7.widget.AppCompatTextView
             android:id="@id/kau_pref_desc"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:maxLines="10"
@@ -90,7 +90,7 @@
 
         <LinearLayout
             android:id="@id/kau_pref_inner_frame"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="0dp"
             android:gravity="center_vertical|end"
             android:orientation="horizontal"

--- a/kpref-activity/src/main/res/layout/kau_pref_text.xml
+++ b/kpref-activity/src/main/res/layout/kau_pref_text.xml
@@ -2,6 +2,8 @@
     android:id="@id/kau_pref_inner_content"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:focusable="false"
+    android:background="@null"
     android:clickable="false"
-    android:background="@null" />
+    android:focusable="false"
+    android:maxLines="3"
+    android:scrollHorizontally="true" />

--- a/kpref-activity/src/main/res/layout/kau_pref_text.xml
+++ b/kpref-activity/src/main/res/layout/kau_pref_text.xml
@@ -4,6 +4,7 @@
     android:layout_height="wrap_content"
     android:background="@null"
     android:clickable="false"
+    android:ellipsize="end"
     android:focusable="false"
     android:maxLines="3"
-    android:scrollHorizontally="true" />
+    android:maxWidth="150dp" />

--- a/sample/src/main/kotlin/ca/allanwang/kau/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/ca/allanwang/kau/sample/MainActivity.kt
@@ -16,10 +16,7 @@ import ca.allanwang.kau.searchview.SearchView
 import ca.allanwang.kau.searchview.bindSearchView
 import ca.allanwang.kau.swipe.SWIPE_EDGE_LEFT
 import ca.allanwang.kau.ui.views.RippleCanvas
-import ca.allanwang.kau.utils.materialDialog
-import ca.allanwang.kau.utils.navigationBarColor
-import ca.allanwang.kau.utils.startActivity
-import ca.allanwang.kau.utils.toast
+import ca.allanwang.kau.utils.*
 import ca.allanwang.kau.xml.showChangelog
 import com.mikepenz.google_material_typeface_library.GoogleMaterial
 
@@ -183,6 +180,17 @@ class MainActivity : KPrefActivity() {
 
         plainText(R.string.kau_about_app) {
             onClick = { _, _, _ -> kauLaunchAbout(AboutActivity::class.java); false }
+        }
+
+        header(R.string.long_prefs)
+
+        checkbox(R.string.checkbox_3, { KPrefSample.check2 }, { KPrefSample.check2 = it; reloadByTitle(R.string.checkbox_3) }) {
+            descRes = R.string.kau_lorem_ipsum
+        }
+
+        text(R.string.text, { KPrefSample.text }, { KPrefSample.text = it }) {
+            descRes = R.string.kau_lorem_ipsum
+            textGetter = { string(R.string.kau_lorem_ipsum) }
         }
 
     }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -24,4 +24,5 @@
     <string name="video_overlay_showcase">Video Overlay Showcase</string>
     <string name="adapter_showcase">Adapter Showcase</string>
     <string name="about_kau">KAU (Kotlin Android Utils) is a collection of common extension functions and complex UIs that can be used in almost all apps. It is meant to implement the shared components, so you can focus on what makes your app unique.</string>
+    <string name="long_prefs">Long Prefs</string>
 </resources>

--- a/sample/src/main/res/xml/kau_changelog.xml
+++ b/sample/src/main/res/xml/kau_changelog.xml
@@ -8,6 +8,10 @@
 	
 	<version title="v3.3.2"/>
     <item text=":kpref-activity: Add visibility toggle to Core contract. Items can override this to show/hide given preferences based on boolean callbacks." />
+	<item text=":kpref-activity: Add width constraint for long text items" />
+	<item text="" />
+	<item text="" />
+	<item text="" />
 	
 	<version title="v3.3.1"/>
     <item text=":core: Open up all logger functions" />


### PR DESCRIPTION
Text items with very large text bodies will overflow, effectively hiding the icon, title, and description. This will add a limit to the text width so this doesn't happen. No limit is imposed on the inner frame, as other items seem to be doing fine (and limiting the frame doesn't work)