### PR TITLE
Fix status bar height for settings activity

### DIFF
--- a/about/src/main/kotlin/ca/allanwang/kau/about/AboutPanelDelegate.kt
+++ b/about/src/main/kotlin/ca/allanwang/kau/about/AboutPanelDelegate.kt
@@ -35,10 +35,10 @@ import ca.allanwang.kau.utils.withMarginDecoration
 import ca.allanwang.kau.xml.kauParseFaq
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.fastadapter.GenericItem
+import java.lang.reflect.Field
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.lang.reflect.Field
 
 /**
  * Created by Allan Wang on 2017-08-02.

--- a/core/src/androidTest/kotlin/ca/allanwang/kau/kpref/KPrefTest.kt
+++ b/core/src/androidTest/kotlin/ca/allanwang/kau/kpref/KPrefTest.kt
@@ -20,10 +20,10 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
+import kotlin.test.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.test.assertEquals
 
 /**
  * Created by Allan Wang on 2017-08-01.

--- a/core/src/androidTest/kotlin/ca/allanwang/kau/utils/KotterknifeTest.kt
+++ b/core/src/androidTest/kotlin/ca/allanwang/kau/utils/KotterknifeTest.kt
@@ -22,12 +22,12 @@ import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
 
 /**
  * Created by Allan Wang on 2017-07-30.

--- a/core/src/androidTest/kotlin/ca/allanwang/kau/utils/UtilsAndroidTest.kt
+++ b/core/src/androidTest/kotlin/ca/allanwang/kau/utils/UtilsAndroidTest.kt
@@ -17,9 +17,9 @@ package ca.allanwang.kau.utils
 
 import android.graphics.Color
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlin.test.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.test.assertEquals
 
 /**
  * Created by Allan Wang on 2018-12-24.

--- a/core/src/androidTest/kotlin/ca/allanwang/kau/xml/FaqTest.kt
+++ b/core/src/androidTest/kotlin/ca/allanwang/kau/xml/FaqTest.kt
@@ -20,9 +20,9 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import ca.allanwang.kau.test.R
+import kotlin.test.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.test.assertEquals
 
 /**
  * Created by Allan Wang on 2017-08-01.

--- a/core/src/main/kotlin/ca/allanwang/kau/internal/KauBaseActivity.kt
+++ b/core/src/main/kotlin/ca/allanwang/kau/internal/KauBaseActivity.kt
@@ -19,10 +19,10 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import ca.allanwang.kau.permissions.kauOnRequestPermissionsResult
 import ca.allanwang.kau.utils.ContextHelper
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Created by Allan Wang on 2017-08-01.

--- a/core/src/main/kotlin/ca/allanwang/kau/utils/CoroutineUtils.kt
+++ b/core/src/main/kotlin/ca/allanwang/kau/utils/CoroutineUtils.kt
@@ -19,14 +19,14 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import ca.allanwang.kau.internal.KauBaseActivity
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 
 object ContextHelper : CoroutineScope {
 

--- a/core/src/main/kotlin/ca/allanwang/kau/utils/Kotterknife.kt
+++ b/core/src/main/kotlin/ca/allanwang/kau/utils/Kotterknife.kt
@@ -34,14 +34,14 @@ import android.app.Dialog
 import android.app.DialogFragment
 import android.app.Fragment
 import android.view.View
+import androidx.fragment.app.DialogFragment as SupportDialogFragment
+import androidx.fragment.app.Fragment as SupportFragment
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import java.util.Collections
 import java.util.WeakHashMap
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
-import androidx.fragment.app.DialogFragment as SupportDialogFragment
-import androidx.fragment.app.Fragment as SupportFragment
 
 fun <V : View> View.bindView(id: Int): ReadOnlyProperty<View, V> = required(id, viewFinder)
 

--- a/core/src/main/kotlin/ca/allanwang/kau/utils/TransitionUtils.kt
+++ b/core/src/main/kotlin/ca/allanwang/kau/utils/TransitionUtils.kt
@@ -21,9 +21,9 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.annotation.TransitionRes
 import androidx.transition.AutoTransition
+import androidx.transition.Transition as SupportTransition
 import androidx.transition.TransitionInflater
 import androidx.transition.TransitionManager
-import androidx.transition.Transition as SupportTransition
 
 /**
  * Created by Allan Wang on 2017-06-24.

--- a/core/src/main/res-public/values/dimens.xml
+++ b/core/src/main/res-public/values/dimens.xml
@@ -11,7 +11,6 @@
     <dimen name="kau_progress_bar_height">1dip</dimen>
     <dimen name="kau_account_image_size">100dp</dimen>
 
-    <dimen name="kau_status_bar_height">24dp</dimen>
     <dimen name="kau_drag_dismiss_distance">112dp</dimen> <!-- 2 * ?android:actionBarSize -->
     <dimen name="kau_drag_dismiss_distance_large">168dp</dimen> <!-- 3 * ?android:actionBarSize -->
 

--- a/core/src/main/res-public/values/public.xml
+++ b/core/src/main/res-public/values/public.xml
@@ -24,7 +24,6 @@
     <public name='kau_splash_logo' type='dimen' />
     <public name='kau_progress_bar_height' type='dimen' />
     <public name='kau_account_image_size' type='dimen' />
-    <public name='kau_status_bar_height' type='dimen' />
     <public name='kau_drag_dismiss_distance' type='dimen' />
     <public name='kau_drag_dismiss_distance_large' type='dimen' />
     <public name='kau_spacing_normal' type='dimen' />

--- a/core/src/test/kotlin/ca/allanwang/kau/kotlin/CoroutineTest.kt
+++ b/core/src/test/kotlin/ca/allanwang/kau/kotlin/CoroutineTest.kt
@@ -15,14 +15,14 @@
  */
 package ca.allanwang.kau.kotlin
 
+import kotlin.test.assertEquals
+import kotlin.test.fail
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.fail
 
 /**
  * Tests geared towards coroutines

--- a/core/src/test/kotlin/ca/allanwang/kau/kotlin/DebounceTest.kt
+++ b/core/src/test/kotlin/ca/allanwang/kau/kotlin/DebounceTest.kt
@@ -15,8 +15,8 @@
  */
 package ca.allanwang.kau.kotlin
 
-import org.junit.Test
 import kotlin.test.assertEquals
+import org.junit.Test
 
 /**
  * Created by Allan Wang on 2017-08-05.

--- a/core/src/test/kotlin/ca/allanwang/kau/kotlin/LazyResettableTest.kt
+++ b/core/src/test/kotlin/ca/allanwang/kau/kotlin/LazyResettableTest.kt
@@ -15,10 +15,10 @@
  */
 package ca.allanwang.kau.kotlin
 
-import org.junit.Before
-import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import org.junit.Before
+import org.junit.Test
 
 /**
  * Created by Allan Wang on 2017-07-29.

--- a/core/src/test/kotlin/ca/allanwang/kau/kotlin/StreamsTest.kt
+++ b/core/src/test/kotlin/ca/allanwang/kau/kotlin/StreamsTest.kt
@@ -15,8 +15,8 @@
  */
 package ca.allanwang.kau.kotlin
 
-import org.junit.Test
 import kotlin.test.assertEquals
+import org.junit.Test
 
 /**
  * Created by Allan Wang on 2017-08-05.

--- a/core/src/test/kotlin/ca/allanwang/kau/ui/ProgressAnimatorTest.kt
+++ b/core/src/test/kotlin/ca/allanwang/kau/ui/ProgressAnimatorTest.kt
@@ -15,11 +15,11 @@
  */
 package ca.allanwang.kau.ui
 
-import org.junit.Test
 import kotlin.math.min
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.Test
 
 class ProgressAnimatorTest {
 

--- a/core/src/test/kotlin/ca/allanwang/kau/utils/UtilsTest.kt
+++ b/core/src/test/kotlin/ca/allanwang/kau/utils/UtilsTest.kt
@@ -16,8 +16,8 @@
 package ca.allanwang.kau.utils
 
 import android.graphics.Color
-import org.junit.Test
 import kotlin.test.assertEquals
+import org.junit.Test
 
 /**
  * Created by Allan Wang on 2017-06-23.

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,9 +1,12 @@
 # Changelog
 
 ## v5.2.0
-* :fastadapter: Migrate fastadapter to v4.x.x
+* :about: Migrate about libraries to v7.x.x
+* :core: Migrate iconics to v4.x.x
 * :core: Automatically switch light mode for navigationBarColor and statusBarColor
 * :core: Remove statusBarLight toggle
+* :core: Remove kau_status_bar_height; height should be found programmatically
+* :fastadapter: Migrate fastadapter to v4.x.x
 
 ## v5.1.0
 * :adapter: Moved fastadapter elements to new module, :fastadapter:. To migrate, simply rename the dependency. If you don't use fast adapter, no changes are necessary

--- a/kpref-activity/src/main/kotlin/ca/allanwang/kau/kpref/activity/KPrefActivity.kt
+++ b/kpref-activity/src/main/kotlin/ca/allanwang/kau/kpref/activity/KPrefActivity.kt
@@ -28,18 +28,17 @@ import ca.allanwang.kau.kpref.activity.items.KPrefItemCore
 import ca.allanwang.kau.ui.views.RippleCanvas
 import ca.allanwang.kau.utils.KAU_LEFT
 import ca.allanwang.kau.utils.KAU_RIGHT
-import ca.allanwang.kau.utils.contentView
 import ca.allanwang.kau.utils.resolveColor
 import ca.allanwang.kau.utils.setMarginTop
 import ca.allanwang.kau.utils.statusBarColor
 import ca.allanwang.kau.utils.withLinearAdapter
 import com.mikepenz.fastadapter.adapters.FastItemAdapter
 import com.mikepenz.fastadapter.select.getSelectExtension
+import java.util.Stack
 import kotlinx.android.synthetic.main.kau_pref_activity.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.Stack
 
 abstract class KPrefActivity : KauBaseActivity(), KPrefActivityContract {
 

--- a/kpref-activity/src/main/kotlin/ca/allanwang/kau/kpref/activity/KPrefActivity.kt
+++ b/kpref-activity/src/main/kotlin/ca/allanwang/kau/kpref/activity/KPrefActivity.kt
@@ -28,7 +28,9 @@ import ca.allanwang.kau.kpref.activity.items.KPrefItemCore
 import ca.allanwang.kau.ui.views.RippleCanvas
 import ca.allanwang.kau.utils.KAU_LEFT
 import ca.allanwang.kau.utils.KAU_RIGHT
+import ca.allanwang.kau.utils.contentView
 import ca.allanwang.kau.utils.resolveColor
+import ca.allanwang.kau.utils.setMarginTop
 import ca.allanwang.kau.utils.statusBarColor
 import ca.allanwang.kau.utils.withLinearAdapter
 import com.mikepenz.fastadapter.adapters.FastItemAdapter
@@ -82,6 +84,10 @@ abstract class KPrefActivity : KauBaseActivity(), KPrefActivityContract {
             setDisplayShowHomeEnabled(true)
             toolbar.setNavigationOnClickListener { onBackPressed() }
             setDisplayShowTitleEnabled(false)
+        }
+        findViewById<View>(android.R.id.content).setOnApplyWindowInsetsListener { _, insets ->
+            kau_toolbar.setMarginTop(insets.systemWindowInsetTop)
+            insets
         }
         window.decorView.systemUiVisibility =
             View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN

--- a/kpref-activity/src/main/res/layout/kau_pref_activity.xml
+++ b/kpref-activity/src/main/res/layout/kau_pref_activity.xml
@@ -13,11 +13,11 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <!-- Margin top will be set to status bar height programmatically -->
     <androidx.appcompat.widget.Toolbar
         android:id="@id/kau_toolbar"
         android:layout_width="0dp"
         android:layout_height="?attr/actionBarSize"
-        android:layout_marginTop="@dimen/kau_status_bar_height"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/mediapicker/src/main/kotlin/ca/allanwang/kau/mediapicker/MediaPickerCore.kt
+++ b/mediapicker/src/main/kotlin/ca/allanwang/kau/mediapicker/MediaPickerCore.kt
@@ -49,9 +49,9 @@ import com.mikepenz.fastadapter.adapters.ItemAdapter
 import com.mikepenz.iconics.dsl.iconicsDrawable
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
-import kotlinx.coroutines.CancellationException
 import java.io.File
 import kotlin.math.min
+import kotlinx.coroutines.CancellationException
 
 /**
  * Created by Allan Wang on 2017-07-23.

--- a/sample/src/main/res/xml/kau_changelog.xml
+++ b/sample/src/main/res/xml/kau_changelog.xml
@@ -11,8 +11,8 @@
     <item text=":core: Migrate iconics to v4.x.x" />
     <item text=":core: Automatically switch light mode for navigationBarColor and statusBarColor" />
     <item text=":core: Remove statusBarLight toggle" />
+    <item text=":core: Remove kau_status_bar_height; height should be found programmatically" />
     <item text=":fastadapter: Migrate fastadapter to v4.x.x" />
-    <item text="" />
     <item text="" />
     <item text="" />
 


### PR DESCRIPTION
Resolves #230 

Remove hardcoded default of 24dp, as phones now have varying status bar heights.

As of this PR, the correct approach is to listen to `setOnApplyWindowInsetsListener` programmatically.

See https://stackoverflow.com/questions/3407256/height-of-status-bar-in-android