### PR TITLE
Remove activity resolution

### DIFF
--- a/core/src/main/kotlin/ca/allanwang/kau/email/EmailBuilder.kt
+++ b/core/src/main/kotlin/ca/allanwang/kau/email/EmailBuilder.kt
@@ -127,6 +127,7 @@ class EmailBuilder(val email: String, val subject: String) {
      * Create the intent and send the request when possible
      * If a stream uri is added, it will automatically be flagged to pass on read permissions
      */
+    @Deprecated(level = DeprecationLevel.WARNING, message = "Resolution fails after Android 11")
     fun execute(context: Context) {
         val intent = getIntent(context)
         intent.extras()


### PR DESCRIPTION
Per https://medium.com/androiddevelopers/package-visibility-in-android-11-cc857f221cd9, we can no longer resolve activities post Android 11 without adding query info in the manifest. Since KAU doesn't need to know which package to use, but rather only if the intent succeeds, we will replace resolution with try catch.

This also marks all toasts into debug only, as the state is returned for the caller to handle.